### PR TITLE
feat: Add GPC Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ WELLKNOWN_GPC = {
 
 Visit `/.well-known/gpc.json`. The GPC support resource lets your site advertise that it recognizes and honors the GPC signal; the actual user preference is conveyed via HTTP header / JS API.
 
+#### GPC Middleware
+
+This tiny middleware is build to act on the per-request GPC signal across your app (e.g., skip trackers or "sale/share" flows), and it works both in sync and async. It reads the browser's Sec-GPC header and exposes `request.gpc`. When the signal is present (`Sec-GPC: 1`), it also appends `Vary: Sec-GPC` so caches/CDNs keep a distinct variant. 
+
+```python
+# settings.py
+MIDDLEWARE = [
+    # ...your other middleware...
+    "django_wellknown.middleware.gpc_middleware",
+]
+```
 
 ## Settings reference
 

--- a/src/django_wellknown/middleware.py
+++ b/src/django_wellknown/middleware.py
@@ -1,0 +1,25 @@
+from asgiref.sync import iscoroutinefunction
+from django.utils.cache import patch_vary_headers
+from django.utils.decorators import sync_and_async_middleware
+
+
+@sync_and_async_middleware
+def gpc_middleware(get_response):
+    if iscoroutinefunction(get_response):
+
+        async def middleware(request):
+            request.gpc = request.headers.get("Sec-GPC") == "1"
+            response = await get_response(request)
+            if request.gpc:
+                patch_vary_headers(response, ["Sec-GPC"])
+            return response
+    else:
+
+        def middleware(request):
+            request.gpc = request.headers.get("Sec-GPC") == "1"
+            response = get_response(request)
+            if request.gpc:
+                patch_vary_headers(response, ["Sec-GPC"])
+            return response
+
+    return middleware

--- a/tests/test_gpc.py
+++ b/tests/test_gpc.py
@@ -1,9 +1,14 @@
-from django.test import override_settings
+from django.test import Client, RequestFactory, override_settings
+
+from django_wellknown.middleware import gpc_middleware
+
+from .views import fake_view
 
 GPC_PATH = "/.well-known/gpc.json"
+rf = RequestFactory()
 
 
-def test_gpc_json_ok(client):
+def test_gpc_json_ok(client: Client):
     resp = client.get(GPC_PATH)
     assert resp.status_code == 200
     data = resp.json()
@@ -12,8 +17,28 @@ def test_gpc_json_ok(client):
 
 
 @override_settings(WELLKNOWN_GPC=None)
-def test_gpc_not_registered_when_disabled(client, reload_urls):
+def test_gpc_not_registered_when_disabled(client: Client, reload_urls):
     reload_urls()
 
     resp = client.get(GPC_PATH)
     assert resp.status_code == 404
+
+
+def test_gpc_signal_present():
+    mw = gpc_middleware(fake_view)
+
+    req = rf.get("/", headers={"sec-gpc": "1"})
+    res = mw(req)
+
+    assert req.gpc is True
+    assert "Sec-GPC" in res["Vary"]
+
+
+def test_gpc_signal_absent():
+    mw = gpc_middleware(fake_view)
+
+    req = rf.get("/")
+    res = mw(req)
+
+    assert req.gpc is False
+    assert not res.has_header("Vary")

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,0 +1,5 @@
+from django.http import HttpResponse
+
+
+def fake_view(request):
+    return HttpResponse("OK")


### PR DESCRIPTION
Add a tiny middleware to act on on the per-request GPC signal. It exposes `request.gpc` and it also appends `Vary: Sec-GPC`.